### PR TITLE
Codethink/typescript codec annotations

### DIFF
--- a/redistributable/TypeScript/morphir/internal/Codecs.ts
+++ b/redistributable/TypeScript/morphir/internal/Codecs.ts
@@ -35,7 +35,9 @@ type CodecMap = Map<string, CodecFunction>;
 //   * https://github.com/Microsoft/TypeScript/issues/3369
 //   * https://stackoverflow.com/a/53136686
 //
-export function buildCodecMap(entries: Array<[string, CodecFunction]>): CodecMap {
+export function buildCodecMap(
+  entries: Array<[string, CodecFunction]>
+): CodecMap {
   return new Map(entries);
 }
 
@@ -141,14 +143,16 @@ export function decodeDict<K, V>(
 
   const inputArray: Array<any> = input;
 
-  return new Map(inputArray.map((item: any) => {
-    if (!(item instanceof Array)) {
-      throw new DecodeError(`Expected array, got ${typeof item}`);
-    }
+  return new Map(
+    inputArray.map((item: any) => {
+      if (!(item instanceof Array)) {
+        throw new DecodeError(`Expected array, got ${typeof item}`);
+      }
 
-    const itemArray: Array<any> = item;
-    return [decodeKey(itemArray[0]), decodeValue(itemArray[1])];
-  }));
+      const itemArray: Array<any> = item;
+      return [decodeKey(itemArray[0]), decodeValue(itemArray[1])];
+    })
+  );
 }
 
 export function decodeList<T>(decodeElement: (any) => T, input: any): Array<T> {

--- a/redistributable/TypeScript/morphir/internal/Codecs.ts
+++ b/redistributable/TypeScript/morphir/internal/Codecs.ts
@@ -215,34 +215,6 @@ export function encodeFloat(value: number): number {
   return value;
 }
 
-export function encodeCustomType(encoderMap: CodecMap, value: any): any {
-  if (encoderMap.has(value["kind"])) {
-    const encoderFn: any = encoderMap.get(value["kind"]);
-    return encoderFn(value);
-  } else {
-    throw new DecodeError(
-      `Didn't find encoder for type variant: ${value["kind"]}`
-    );
-  }
-}
-
-export function encodeCustomTypeVariant(
-  argNames: Array<string>,
-  argEncoders: CodecList,
-  value: object
-): Array<any> {
-  if (argNames.length == 0) {
-    return value["kind"];
-  } else {
-    var result = [value["kind"]];
-    for (var i = 0; i < argNames.length; i++) {
-      const name = argNames[i];
-      result.push(argEncoders[i](value[name]));
-    }
-    return result;
-  }
-}
-
 export function encodeDict<K, V>(
   encodeKey: (any) => K,
   encodeValue: (any) => V,

--- a/src/Morphir/TypeScript/AST.elm
+++ b/src/Morphir/TypeScript/AST.elm
@@ -66,6 +66,11 @@ type Expression
     = ArrayLiteralExpression (List Expression)
     | Call CallExpression
     | Identifier String
+    | IntLiteralExpression Int
+    | IndexedExpression
+        { object : Expression
+        , index : Expression
+        }
     | MemberExpression
         { object : Expression
         , member : Expression
@@ -108,6 +113,8 @@ parameter modifiers name typeAnnotation =
 type Statement
     = FunctionDeclaration
         { name : String
+        , typeVariables : List TypeExp
+        , returnType : Maybe TypeExp
         , scope : FunctionScope
         , parameters : List Parameter
         , body : List Statement
@@ -117,6 +124,7 @@ type Statement
     | AssignmentStatement Expression (Maybe TypeExp) Expression
     | ExpressionStatement Expression
     | ReturnStatement Expression
+    | SwitchStatement Expression (List ( Expression, List Statement ))
 
 
 {-| Represents a type definition.
@@ -164,6 +172,7 @@ Only a small subset of the type-system is currently implemented.
 type TypeExp
     = Any
     | Boolean
+    | FunctionTypeExp (List Parameter) TypeExp
     | List TypeExp {- Represents a Morphir 'List' type, as a Typescript 'Array' type -}
     | LiteralString String
     | Map TypeExp TypeExp

--- a/src/Morphir/TypeScript/Backend/Types.elm
+++ b/src/Morphir/TypeScript/Backend/Types.elm
@@ -470,6 +470,8 @@ generateDecoderFunction variables typeName access typeExp =
     in
     TS.FunctionDeclaration
         { name = prependDecodeToName typeName
+        , typeVariables = []
+        , returnType = Nothing
         , scope = TS.ModuleFunction
         , parameters = variableParams ++ [ inputParam ]
         , privacy = access |> mapPrivacy
@@ -525,6 +527,8 @@ generateConstructorDecoderFunction constructor =
     in
     TS.FunctionDeclaration
         { name = prependDecodeToName constructor.name
+        , typeVariables = []
+        , returnType = Nothing
         , scope = TS.ModuleFunction
         , privacy = constructor.privacy
         , parameters = decoderParams ++ [ inputParam ]
@@ -576,6 +580,8 @@ generateUnionDecoderFunction typeName privacy typeVariables constructors =
     in
     TS.FunctionDeclaration
         { name = prependDecodeToName typeName
+        , typeVariables = []
+        , returnType = Nothing
         , scope = TS.ModuleFunction
         , privacy = privacy
         , parameters = decoderParams ++ [ inputParam ]
@@ -716,6 +722,8 @@ generateEncoderFunction variables typeName access typeExp =
     in
     TS.FunctionDeclaration
         { name = prependEncodeToName typeName
+        , typeVariables = []
+        , returnType = Nothing
         , scope = TS.ModuleFunction
         , parameters = variableParams ++ [ valueParam ]
         , privacy = access |> mapPrivacy
@@ -767,6 +775,8 @@ generateConstructorEncoderFunction constructor =
     in
     TS.FunctionDeclaration
         { name = prependEncodeToName constructor.name
+        , typeVariables = []
+        , returnType = Nothing
         , scope = TS.ModuleFunction
         , privacy = constructor.privacy
         , parameters = encoderParams ++ [ valueParam ]
@@ -818,6 +828,8 @@ generateUnionEncoderFunction typeName privacy typeVariables constructors =
     in
     TS.FunctionDeclaration
         { name = prependEncodeToName typeName
+        , typeVariables = []
+        , returnType = Nothing
         , scope = TS.ModuleFunction
         , privacy = privacy
         , parameters = encoderParams ++ [ valueParam ]
@@ -838,6 +850,8 @@ generateConstructorConstructorFunction { name, privacy, args, typeVariables, typ
     in
     TS.FunctionDeclaration
         { name = "constructor"
+        , typeVariables = []
+        , returnType = Nothing
         , scope = TS.ClassMemberFunction
         , privacy = privacy
         , parameters = argParams

--- a/src/Morphir/TypeScript/Backend/Types.elm
+++ b/src/Morphir/TypeScript/Backend/Types.elm
@@ -28,6 +28,14 @@ type alias ConstructorDetail a =
     }
 
 
+inputIndexArg : Int -> TS.Expression
+inputIndexArg index =
+    TS.IndexedExpression
+        { object = TS.Identifier "input"
+        , index = TS.IntLiteralExpression index
+        }
+
+
 prependDecodeToName : Name -> String
 prependDecodeToName name =
     ("decode" :: name) |> Name.toCamelCase
@@ -294,6 +302,13 @@ mapTypeExp tpe =
             TS.UnhandledType "Function"
 
 
+decoderTypeSignature : TS.TypeExp -> TS.TypeExp
+decoderTypeSignature typeExp =
+    TS.FunctionTypeExp
+        [ TS.Parameter [] "input" (Just TS.Any) ]
+        typeExp
+
+
 {-| Reference a symbol in the Morphir.Internal.Codecs module.
 -}
 codecsModule : String -> TS.Expression
@@ -320,12 +335,8 @@ buildCodecMap array =
         }
 
 
-decoderExpression : TypeVariablesList -> Type.Type a -> TS.CallExpression
-decoderExpression customTypeVars typeExp =
-    let
-        inputArg =
-            TS.Identifier "input"
-    in
+decoderExpression : TypeVariablesList -> Type.Type a -> TS.Expression -> TS.CallExpression
+decoderExpression customTypeVars typeExp inputArg =
     case typeExp of
         Type.Reference _ ( [ [ "morphir" ], [ "s", "d", "k" ] ], [ [ "basics" ] ], [ "bool" ] ) [] ->
             { function = codecsModule "decodeBoolean", arguments = [ inputArg ] }
@@ -441,7 +452,7 @@ specificDecoderForType : TypeVariablesList -> Type.Type ta -> TS.Expression
 specificDecoderForType customTypeVars typeExp =
     let
         expression =
-            decoderExpression customTypeVars typeExp
+            decoderExpression customTypeVars typeExp (TS.Identifier "input")
 
         removeInputArg arguments =
             arguments |> List.take (List.length arguments - 1)
@@ -452,26 +463,33 @@ specificDecoderForType customTypeVars typeExp =
 generateDecoderFunction : TypeVariablesList -> Name -> Access -> Type.Type ta -> TS.Statement
 generateDecoderFunction variables typeName access typeExp =
     let
+        variableTypeExpressions : List TS.TypeExp
+        variableTypeExpressions =
+            variables |> List.map Name.toTitleCase |> List.map (\var -> TS.Variable var)
+
         call : TS.CallExpression
         call =
-            decoderExpression variables typeExp
+            decoderExpression variables typeExp (TS.Identifier "input")
 
         variableParams : List TS.Parameter
         variableParams =
             variables
                 |> List.map
                     (\var ->
-                        TS.parameter [] (prependDecodeToName var) Nothing
+                        TS.parameter
+                            []
+                            (prependDecodeToName var)
+                            (Just (decoderTypeSignature (TS.Variable (Name.toTitleCase var))))
                     )
 
         inputParam : TS.Parameter
         inputParam =
-            TS.parameter [] "input" Nothing
+            TS.parameter [] "input" (Just TS.Any)
     in
     TS.FunctionDeclaration
         { name = prependDecodeToName typeName
-        , typeVariables = []
-        , returnType = Nothing
+        , typeVariables = variableTypeExpressions
+        , returnType = Just (TS.TypeRef ( [], [], typeName ) variableTypeExpressions)
         , scope = TS.ModuleFunction
         , parameters = variableParams ++ [ inputParam ]
         , privacy = access |> mapPrivacy
@@ -482,110 +500,154 @@ generateDecoderFunction variables typeName access typeExp =
 generateConstructorDecoderFunction : ConstructorDetail ta -> TS.Statement
 generateConstructorDecoderFunction constructor =
     let
+        variableTypeExpressions : List TS.TypeExp
+        variableTypeExpressions =
+            constructor.typeVariableNames |> List.map Name.toTitleCase |> List.map (\var -> TS.Variable var)
+
         decoderParams : List TS.Parameter
         decoderParams =
             constructor.typeVariableNames
                 |> List.map
                     (\var ->
-                        TS.parameter [] (prependDecodeToName var) Nothing
+                        TS.parameter
+                            []
+                            (prependDecodeToName var)
+                            (Just (decoderTypeSignature (TS.Variable (Name.toTitleCase var))))
                     )
 
         inputParam : TS.Parameter
         inputParam =
-            TS.parameter [] "input" Nothing
+            TS.parameter [] "input" (Just TS.Any)
 
         kind =
             TS.StringLiteralExpression (constructor.name |> Name.toTitleCase)
 
-        argNames =
-            TS.ArrayLiteralExpression
-                (constructor.args
-                    |> List.map (Tuple.first >> Name.toCamelCase >> TS.StringLiteralExpression)
-                )
-
-        argDecoders =
-            TS.ArrayLiteralExpression
-                (constructor.args
-                    |> List.map Tuple.second
-                    |> List.map (specificDecoderForType constructor.typeVariableNames)
-                )
-
-        input =
-            TS.Identifier "input"
-
-        call : TS.Expression
-        call =
+        validateCall : TS.Expression
+        validateCall =
             TS.Call
-                { function = codecsModule "decodeCustomTypeVariant"
+                { function = codecsModule "preprocessCustomTypeVariant"
                 , arguments =
                     [ kind
-                    , argNames
-                    , argDecoders
-                    , input
+                    , constructor.args |> List.length |> TS.IntLiteralExpression
+                    , TS.Identifier "input"
                     ]
+                }
+
+        {--Given an array of inputs (eg  ["PetTrio", "Dalmatian", "Tabby", "Angora"] )
+           and a list of constructor argument names and types (eg [("arg1", DogType), ("arg2", CatType), ("arg3", RabbitType)] )
+           argDecoderCalls will generate a list of typescript function calls, to decode each of the arguments
+           eg [ decodeDog("Dalmatian"), decodeCat("Tabby"), decodeRabbit("Angora") ]
+           This generates a list of decoded elements.
+-}
+        argDecoderCalls : List TS.Expression
+        argDecoderCalls =
+            constructor.args
+                |> List.map Tuple.second
+                |> List.indexedMap
+                    (\index ->
+                        \typExp ->
+                            TS.Call
+                                (decoderExpression
+                                    constructor.typeVariableNames
+                                    typExp
+                                    (inputIndexArg (index + 1))
+                                )
+                    )
+
+        {--newCall takes the list of decoded elements (as created by argDecoderCalls)
+           and passes it as an argument to a TypeScript class constructor
+           ( eg `new PetTrio()` )
+-}
+        newCall : TS.Expression
+        newCall =
+            TS.NewExpression
+                { constructor = constructor.name |> Name.toTitleCase
+                , arguments = argDecoderCalls
                 }
     in
     TS.FunctionDeclaration
         { name = prependDecodeToName constructor.name
-        , typeVariables = []
-        , returnType = Nothing
+        , typeVariables = variableTypeExpressions
+        , returnType = Just (TS.TypeRef ( [], [], constructor.name ) variableTypeExpressions)
         , scope = TS.ModuleFunction
         , privacy = constructor.privacy
         , parameters = decoderParams ++ [ inputParam ]
-        , body = [ TS.ReturnStatement call ]
+        , body =
+            [ TS.ExpressionStatement validateCall
+            , TS.ReturnStatement newCall
+            ]
         }
 
 
 generateUnionDecoderFunction : Name -> TS.Privacy -> List Name -> List (ConstructorDetail ta) -> TS.Statement
 generateUnionDecoderFunction typeName privacy typeVariables constructors =
     let
+        variableTypeExpressions : List TS.TypeExp
+        variableTypeExpressions =
+            typeVariables |> List.map Name.toTitleCase |> List.map (\var -> TS.Variable var)
+
         decoderParams : List TS.Parameter
         decoderParams =
             typeVariables
                 |> List.map
                     (\var ->
-                        TS.parameter [] (prependDecodeToName var) Nothing
+                        TS.parameter
+                            []
+                            (prependDecodeToName var)
+                            (Just (decoderTypeSignature (TS.Variable (Name.toTitleCase var))))
                     )
 
         inputParam : TS.Parameter
         inputParam =
-            TS.parameter [] "input" Nothing
+            TS.parameter [] "input" (Just TS.Any)
 
-        getCodecMapEntry : ConstructorDetail ta -> TS.Expression
-        getCodecMapEntry constructor =
-            TS.ArrayLiteralExpression
-                [ TS.StringLiteralExpression (constructor.name |> Name.toTitleCase)
-                , bindArgumentsToFunction
-                    (constructor.name |> prependDecodeToName |> TS.Identifier)
-                    (constructor.typeVariableNames |> List.map (prependDecodeToName >> TS.Identifier))
-                ]
+        kindCall : TS.Statement
+        kindCall =
+            TS.LetStatement
+                (TS.Identifier "kind")
+                Nothing
+                (TS.Call
+                    { function = codecsModule "parseKindFromCustomTypeInput"
+                    , arguments = [ TS.Identifier "input" ]
+                    }
+                )
 
-        codecMap : TS.Expression
-        codecMap =
-            constructors |> List.map getCodecMapEntry |> TS.ArrayLiteralExpression |> buildCodecMap
-
-        call : TS.Expression
-        call =
-            TS.Call
-                { function =
-                    TS.MemberExpression
-                        { object = TS.Identifier "codecs"
-                        , member = TS.Identifier "decodeCustomType"
-                        }
+        errorCall : TS.Statement
+        errorCall =
+            (TS.Call >> TS.ExpressionStatement)
+                { function = codecsModule "raiseDecodeErrorFromCustomType"
                 , arguments =
-                    [ codecMap
-                    , TS.Identifier "input"
+                    [ TS.StringLiteralExpression (typeName |> Name.toTitleCase)
+                    , TS.Identifier "kind"
                     ]
                 }
+
+        constructorToCaseBlock : ConstructorDetail ta -> ( TS.Expression, List TS.Statement )
+        constructorToCaseBlock constructor =
+            ( constructor.name |> Name.toTitleCase |> TS.StringLiteralExpression
+            , [ TS.ReturnStatement
+                    (TS.Call
+                        { function = constructor.name |> prependDecodeToName |> TS.Identifier
+                        , arguments = (constructor.typeVariableNames |> List.map (prependDecodeToName >> TS.Identifier)) ++ [ TS.Identifier "input" ]
+                        }
+                    )
+              ]
+            )
+
+        switchStatement : TS.Statement
+        switchStatement =
+            TS.SwitchStatement
+                (TS.Identifier "kind")
+                (constructors |> List.map constructorToCaseBlock)
     in
     TS.FunctionDeclaration
         { name = prependDecodeToName typeName
-        , typeVariables = []
-        , returnType = Nothing
+        , typeVariables = variableTypeExpressions
+        , returnType = Just (TS.TypeRef ( [], [], typeName ) variableTypeExpressions)
         , scope = TS.ModuleFunction
         , privacy = privacy
         , parameters = decoderParams ++ [ inputParam ]
-        , body = [ TS.ReturnStatement call ]
+        , body = [ kindCall, switchStatement, errorCall ]
         }
 
 

--- a/src/Morphir/TypeScript/PrettyPrinter/Expressions.elm
+++ b/src/Morphir/TypeScript/PrettyPrinter/Expressions.elm
@@ -1,9 +1,9 @@
-module Morphir.TypeScript.PrettyPrinter.Expressions exposing (mapField, mapGenericVariables, mapObjectExp, mapTypeExp, namespaceNameFromPackageAndModule)
+module Morphir.TypeScript.PrettyPrinter.Expressions exposing (..)
 
 import Morphir.File.SourceCode exposing (Doc, concat, indentLines, newLine)
 import Morphir.IR.Name as Name
 import Morphir.IR.Path exposing (Path)
-import Morphir.TypeScript.AST exposing (ObjectExp, Privacy(..), TypeDef(..), TypeExp(..), namespaceNameFromPackageAndModule)
+import Morphir.TypeScript.AST exposing (ObjectExp, Parameter, Privacy(..), TypeDef(..), TypeExp(..), namespaceNameFromPackageAndModule)
 
 
 defaultIndent =
@@ -22,6 +22,26 @@ mapGenericVariables variables =
                 , String.join ", " (variables |> List.map mapTypeExp)
                 , ">"
                 ]
+
+
+mapParameter : Parameter -> String
+mapParameter { modifiers, name, typeAnnotation } =
+    concat
+        [ modifiers |> String.join " "
+        , " "
+        , name
+        , mapMaybeAnnotation typeAnnotation
+        ]
+
+
+mapMaybeAnnotation : Maybe TypeExp -> String
+mapMaybeAnnotation maybeTypeExp =
+    case maybeTypeExp of
+        Nothing ->
+            ""
+
+        Just typeExp ->
+            ": " ++ mapTypeExp typeExp
 
 
 {-| Map a field to text (from an object or interface)
@@ -56,6 +76,14 @@ mapTypeExp typeExp =
 
         Boolean ->
             "boolean"
+
+        FunctionTypeExp params rtnTypeExp ->
+            concat
+                [ "("
+                , params |> List.map mapParameter |> String.join ", "
+                , ") => "
+                , mapTypeExp rtnTypeExp
+                ]
 
         List listType ->
             "Array<" ++ mapTypeExp listType ++ ">"


### PR DESCRIPTION
Reworks the decoders and encoders for Custom Types and Custom Type Variants,
Adds type annotations to all encoder and decoder functions.
* Type Variables for generic functions
* Type annotations for function parameters
* Return Type annotations for the functions
* eg `validateList<A>(inputList: Array<A>): bool {...}`

# Terms

> THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE TERMS OF THE CCLA DATED 2017-11-07 WITH FINOS/LINUX FOUNDATION (FORMERLY THE SYMPHONY SOFTWARE FOUNDATION CCLA).
>
> THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
